### PR TITLE
Fix authentication for new Blink API (OAuth2 - Nov 2025)

### DIFF
--- a/BlinkVideoDownloader.ps1
+++ b/BlinkVideoDownloader.ps1
@@ -2,7 +2,7 @@
 #
 # Author: Nayrk
 # Date: 12/28/2018
-# Last Updated: 02/03/2021
+# Last Updated: 11/23/2025
 # Purpose: To download all Blink videos locally to the PC. Existing videos will be skipped.
 # Output: All Blink videos downloaded in the following directory format.
 #         Default Location Desktop - "C:\temp\Blink"
@@ -14,8 +14,13 @@
 # Fixed By: colinreid89 on 05/15/2020
 # Fixed By: tyuhas on 02/03/2021
 # Fixed By: ttteee90 on 03/19/2021
+# Fixed By: tpgal on 11/23/2025 - OAuth2 migration fix
+#             Solution based on blinkpy's OAuth2 implementation (https://github.com/fronzbot/blinkpy)
+#             Adapted to PowerShell by Claude Sonnet 4.5 (Anthropic)
+#             Analysis and debugging with user collaboration
 # Updates: Added infinite loop to re-run every 30 minutes as a keep alive to bypass pin prompt from Blink/Amazon
 #          03/22/2021 - Cleaned up the code and added more debug messages. Added try/catch on invalid pin.
+#          11/23/2025 - Migrated to OAuth2 authentication endpoint with automatic token refresh and 2FA support
 #######################################################################################################################
 
 # Change saveDirectory directory if you want the Blink Files to be saved somewhere else, default is user Desktop
@@ -34,6 +39,12 @@ $blinkAPIServer = 'rest-prod.immedia-semi.com'
 # Use this server below if you are in Germany. Remove the # symbol below.
 # $blinkAPIServer = 'prde.immedia-semi.com'
 
+# OAuth Constants (New for 2025)
+$oauthServer = 'api.oauth.blink.com'
+$oauthClientId = 'android'
+$oauthGrantType = 'password'
+$oauthScope = 'client'
+
 #######################################################################################################################
 #
 # Do not change anything below unless you know what you are doing or you want to...
@@ -43,98 +54,265 @@ $blinkAPIServer = 'rest-prod.immedia-semi.com'
 if($email -eq "Your Email Here") { Write-Host 'Please enter your email by modifying the line: $email = "Your Email Here"'; pause; exit;}
 if($password -eq "Your Password Here") { Write-Host 'Please enter your password by modifying the line: $password = "Your Password Here"'; pause; exit;}
 
-# Headers to send to Blink's server for authentication
-$headers = @{
-    "Host" = "$blinkAPIServer"
-    "Content-Type" = "application/json"
+# Function to URL-encode a string (compatible with all PowerShell versions)
+function ConvertTo-UrlEncoded {
+    param([string]$Value)
+    
+    # Character map for URL encoding
+    $urlEncoded = ""
+    foreach ($char in $Value.ToCharArray()) {
+        $ascii = [int][char]$char
+        
+        # Check if character needs encoding
+        if (($ascii -ge 48 -and $ascii -le 57) -or   # 0-9
+            ($ascii -ge 65 -and $ascii -le 90) -or   # A-Z
+            ($ascii -ge 97 -and $ascii -le 122) -or  # a-z
+            $char -eq '-' -or $char -eq '_' -or 
+            $char -eq '.' -or $char -eq '~') {
+            $urlEncoded += $char
+        } else {
+            # Encode the character as %XX
+            $urlEncoded += '%' + ([System.String]::Format("{0:X2}", $ascii))
+        }
+    }
+    return $urlEncoded
 }
 
-# Credential data to send
-$body = @{
-    "email" = "$email"
-    "password" = "$password"
-	"unique_id" = "00000000-1111-0000-1111-00000000000"
-} | ConvertTo-Json
+# Global variables for token management
+$script:authToken = $null
+$script:refreshToken = $null
+$script:tokenExpirationTime = $null
+$script:region = $null
+$script:accountID = $null
+$script:lastTokenCheck = 0
 
-# Login URL of Blink API
-$uri = "https://$blinkAPIServer/api/v5/account/login"
+# Function to perform OAuth login
+function Invoke-BlinkLogin {
+    param(
+        [string]$TwoFactorCode = $null,
+        [switch]$IsRefresh = $false
+    )
+    
+    # Headers for OAuth login
+    $loginHeaders = @{
+        "Content-Type" = "application/x-www-form-urlencoded"
+        "User-Agent" = "Blinkpy/0.22.0"
+        "hardware_id" = "Blinkpy"
+    }
+    
+    # Add 2FA code to headers if provided
+    if ($TwoFactorCode) {
+        $loginHeaders["2fa-code"] = $TwoFactorCode
+    }
 
-# Authenticate credentials with Blink Server and get our token for future requests
-$response = Invoke-RestMethod -UseBasicParsing $uri -Method Post -Headers $headers -Body $body
+    # Credential data in URL-encoded format
+    if ($IsRefresh -and $script:refreshToken) {
+        # Use refresh token for renewal
+        $bodyParams = @{
+            "grant_type" = "refresh_token"
+            "refresh_token" = $script:refreshToken
+            "client_id" = $oauthClientId
+        }
+    } else {
+        # Use credentials for initial login
+        $bodyParams = @{
+            "username" = $email
+            "password" = $password
+            "grant_type" = $oauthGrantType
+            "client_id" = $oauthClientId
+            "scope" = $oauthScope
+        }
+    }
+
+    # Convert to URL-encoded string
+    $bodyString = ($bodyParams.GetEnumerator() | ForEach-Object { "$($_.Key)=$(ConvertTo-UrlEncoded $_.Value)" }) -join '&'
+
+    # OAuth Login URL
+    $loginUri = "https://$oauthServer/oauth/token"
+
+    # Authenticate credentials with Blink OAuth Server
+    try {
+        $response = Invoke-RestMethod -UseBasicParsing $loginUri -Method Post -Headers $loginHeaders -Body $bodyString -ErrorAction Stop
+        return @{
+            Success = $true
+            Response = $response
+        }
+    } catch {
+        $statusCode = $_.Exception.Response.StatusCode.Value__
+        return @{
+            Success = $false
+            StatusCode = $statusCode
+            Error = $_.Exception.Message
+        }
+    }
+}
+
+# Function to check if token needs refresh
+function Test-TokenNeedsRefresh {
+    if ($null -eq $script:tokenExpirationTime) {
+        return $true
+    }
+    
+    $currentTime = [Math]::Floor([decimal](Get-Date(Get-Date).ToUniversalTime()-uformat "%s"))
+    $timeUntilExpiration = $script:tokenExpirationTime - $currentTime
+    
+    # Refresh if less than 5 minutes (300 seconds) until expiration
+    return $timeUntilExpiration -lt 300
+}
+
+# Function to refresh authentication token
+function Update-AuthToken {
+    param(
+        [switch]$Force = $false
+    )
+    
+    if ($Force -or (Test-TokenNeedsRefresh)) {
+        echo "Token expiring soon, refreshing authentication..."
+        
+        # Try to refresh using refresh_token first
+        $refreshResult = Invoke-BlinkLogin -IsRefresh
+        
+        # If refresh fails, do a full re-login
+        if (-not $refreshResult.Success) {
+            echo "Refresh token failed, performing full re-authentication..."
+            $refreshResult = Invoke-BlinkLogin
+            
+            # Check if 2FA is required
+            if (-not $refreshResult.Success -and $refreshResult.StatusCode -eq 412) {
+                Write-Host "Two-factor authentication required. Please check your email or SMS for the 2FA code."
+                $twoFactorCode = Read-Host -Prompt "Enter your 2FA code"
+                
+                if (-not $twoFactorCode -or $twoFactorCode.Trim() -eq "") {
+                    Write-Host "No 2FA code provided. Cannot refresh token."
+                    return $false
+                }
+                
+                $refreshResult = Invoke-BlinkLogin -TwoFactorCode $twoFactorCode
+            }
+        }
+        
+        if ($refreshResult.Success) {
+            $response = $refreshResult.Response
+            $script:authToken = $response.access_token
+            $script:refreshToken = $response.refresh_token
+            
+            # Calculate expiration time (current time + expires_in)
+            $currentTime = [Math]::Floor([decimal](Get-Date(Get-Date).ToUniversalTime()-uformat "%s"))
+            $script:tokenExpirationTime = $currentTime + $response.expires_in
+            $script:lastTokenCheck = $currentTime
+            
+            echo "Token refreshed successfully. Valid for $($response.expires_in) seconds."
+            return $true
+        } else {
+            Write-Host "Failed to refresh token. Script may stop working."
+            return $false
+        }
+    }
+    return $true
+}
+
+# Function to get current auth headers (always fresh)
+function Get-AuthHeaders {
+    # Check token every time headers are requested
+    if (-not (Update-AuthToken)) {
+        Write-Host "Warning: Unable to refresh token, using potentially expired token."
+    }
+    
+    return @{
+        "Authorization" = "Bearer $script:authToken"
+        "Content-Type" = "application/json"
+    }
+}
+
+# Initial login attempt
+echo "Performing initial authentication..."
+$loginResult = Invoke-BlinkLogin
+
+# Check if 2FA is required (HTTP 412)
+if (-not $loginResult.Success -and $loginResult.StatusCode -eq 412) {
+    Write-Host "Two-factor authentication required. Please check your email or SMS for the 2FA code."
+    $twoFactorCode = Read-Host -Prompt "Enter your 2FA code"
+    
+    if (-not $twoFactorCode -or $twoFactorCode.Trim() -eq "") {
+        Write-Host "No 2FA code provided. Exiting."
+        pause
+        exit
+    }
+    
+    # Retry login with 2FA code
+    $loginResult = Invoke-BlinkLogin -TwoFactorCode $twoFactorCode
+}
+
+# Check final login result
+if (-not $loginResult.Success) {
+    Write-Host "Login failed. Please verify your credentials and try again."
+    pause
+    exit
+}
+
+$response = $loginResult.Response
+
 if(-not $response){
-    echo "Invalid credentials provided. Please verify email and password."
+    echo "No response received from server."
     pause
     exit
-} else {
-    echo "Authenticated with Blink successfully. Please check your email or SMS/Text on your phone for the pin."
 }
 
-# Get the object data
-$region = $response.account.tier   #region.tier
-$authToken = $response.auth.token
-$accountID = $response.account.account_id
-$userid = $response.account.user_id
+# Extract OAuth token and set expiration time
+$script:authToken = $response.access_token
+$script:refreshToken = $response.refresh_token
+$expiresIn = $response.expires_in
 
-# Fix provided by @tyuhas 
-$clientID = $response.account.client_id
+# Calculate expiration time
+$currentTime = [Math]::Floor([decimal](Get-Date(Get-Date).ToUniversalTime()-uformat "%s"))
+$script:tokenExpirationTime = $currentTime + $expiresIn
+$script:lastTokenCheck = $currentTime
 
-#echo $response
-#echo $region
-#echo $authToken
-#echo $accountID
-#echo $clientID
-
-
-
-$pin = Read-Host -Prompt 'Input PIN'
-$uri = 'https://rest-'+ $region +".immedia-semi.com/api/v4/account/"+ $accountID +'/client/'+ $clientID +"/pin/verify"
-#$uri = "https://rest-prod.immedia-semi.com/api/v4/account/"+ $accountID +'/client/'+ $clientID +"/pin/verify"
-#Headers to send for PIN authentication
-$pin_headers = @{
-   "CONTENT-TYPE" = "application/json"
-   "TOKEN-AUTH" = $authToken
+if(-not $script:authToken) {
+    Write-Host "Failed to obtain access token. Please try again."
+    pause
+    exit
 }
 
+$expirationDate = (Get-Date).AddSeconds($expiresIn)
+echo "Access token obtained (valid for $expiresIn seconds, expires at $($expirationDate.ToString('HH:mm:ss')))"
 
+# Get tier information
+$tierUri = "https://$blinkAPIServer/api/v1/users/tier_info"
+$tierHeaders = @{
+    "Content-Type" = "application/json"
+    "Authorization" = "Bearer $script:authToken"
+    "User-Agent" = "Blinkpy/0.22.0"
+}
 
-#PIN goes in the body
-$pin_body = @{
-    "pin" = $pin
-} | ConvertTo-Json
-
-#Echo "URI:" $uri
-
-# Added try/catch to catch the invalid pin
 try {
-    $pin_response = Invoke-RestMethod -UseBasicParsing $uri -Method Post -Headers $pin_headers -Body $pin_body
+    $tierResponse = Invoke-RestMethod -UseBasicParsing $tierUri -Method Get -Headers $tierHeaders -ErrorAction Stop
 } catch {
-    echo "Invalid Pin response. Please re-run the script again and use the same pin within the first minute."
+    Write-Host "Failed to get account information. Please try again."
     pause
     exit
 }
+
+# Extract tier data
+$script:region = $tierResponse.tier
+$script:accountID = $tierResponse.account_id
+
+if(-not $script:region -or -not $script:accountID) {
+    Write-Host "Failed to obtain account details. Please try again."
+    pause
+    exit
+}
+
+echo "Authenticated with Blink successfully (Region: $script:region, Account: $script:accountID)"
 
 while (1)
 {
-    echo "Script will re-run every 30 minutes as a keep alive to Blink server."
-	#echo $response
-	#echo $region
-	#echo $authToken
-	#echo $accountID
-
-	# Headers to send to Blink's server after authentication with our token
-	$headers = @{
-		# "Host" = "$blinkAPIServer"
-		"TOKEN_AUTH" = "$authToken"
-	}
-
-	# Get list of networks
-	#$uri = "https://rest-u017.immedia-semi.com/api/v1/camera/usage"
-	$uri = 'https://rest-'+ $region +".immedia-semi.com/api/v1/camera/usage"
-	#echo $uri
-
-	# Use old endpoint to get list of cameras with respect to network id    
-    $sync_units = Invoke-RestMethod -UseBasicParsing $uri -Method Get -Headers $headers
-    
+	echo "`nStarting download cycle..."
+	
+	# Get list of networks (headers always fresh)
+	$uri = 'https://rest-'+ $script:region +".immedia-semi.com/api/v1/camera/usage"
+	$sync_units = Invoke-RestMethod -UseBasicParsing $uri -Method Get -Headers (Get-AuthHeaders)
+	
 	foreach($sync_unit in $sync_units.networks)
 	{
 		$network_id = $sync_unit.network_id
@@ -143,10 +321,10 @@ while (1)
 		foreach($camera in $sync_unit.cameras){
 			$cameraName = $camera.name
 			$cameraId = $camera.id
-			$uri = 'https://rest-'+ $region +".immedia-semi.com/network/$network_id/camera/$cameraId"
+			$uri = 'https://rest-'+ $script:region +".immedia-semi.com/network/$network_id/camera/$cameraId"
 			
-			
-			$camera = Invoke-RestMethod -UseBasicParsing $uri -Method Get -Headers $headers
+			# Get camera info with fresh headers
+			$camera = Invoke-RestMethod -UseBasicParsing $uri -Method Get -Headers (Get-AuthHeaders)
 			$cameraThumbnail = $camera.camera_status.thumbnail
 
 			# Create Blink Directory to store videos if it doesn't exist
@@ -156,33 +334,26 @@ while (1)
 			}
 
 			# Download camera thumbnail
-			$thumbURL = 'https://rest-'+ $region +'.immedia-semi.com' + $cameraThumbnail + ".jpg"
+			$thumbURL = 'https://rest-'+ $script:region +'.immedia-semi.com' + $cameraThumbnail + ".jpg"
 			$thumbPath = "$path\" + "thumbnail_" + $cameraThumbnail.Split("/")[-1] + ".jpg"
 			
 			# Skip if already downloaded
 			if (-not (Test-Path $thumbPath)){
 				echo "Downloading thumbnail for $cameraName camera in $networkName."
-				Invoke-RestMethod -UseBasicParsing $thumbURL -Method Get -Headers $headers -OutFile $thumbPath
+				Invoke-RestMethod -UseBasicParsing $thumbURL -Method Get -Headers (Get-AuthHeaders) -OutFile $thumbPath
 			}
 		}
 	}
 
 	$pageNum = 1
+	$videoCount = 0
 
 	# Continue to download videos from each page until all are downloaded
 	while ( 1 )
 	{
-		# List of videos from Blink's server
-		# $uri = 'https://rest-'+ $region +'.immedia-semi.com/api/v2/videos/page/' + $pageNum
-		
-		# Changed to use old endpoint
-		#$uri = 'https://rest-'+ $region +'.immedia-semi.com/api/v2/videos/changed?since=2016-01-01T23:11:21+0000&page=' + $pageNum
-
-		# Changed endpoint again
-		$uri = 'https://rest-'+ $region +'.immedia-semi.com/api/v1/accounts/'+ $accountID +'/media/changed?since=2015-04-19T23:11:20+0000&page=' + $pageNum
-
-		# Get the list of video clip information from each page from Blink
-		$response = Invoke-RestMethod -UseBasicParsing $uri -Method Get -Headers $headers
+		# Get media list with fresh headers
+		$uri = 'https://rest-'+ $script:region +'.immedia-semi.com/api/v1/accounts/'+ $script:accountID +'/media/changed?since=2015-04-19T23:11:20+0000&page=' + $pageNum
+		$response = Invoke-RestMethod -UseBasicParsing $uri -Method Get -Headers (Get-AuthHeaders)
 		
 		# No more videos to download, exit from loop
 		if(-not $response.media){
@@ -206,17 +377,19 @@ while (1)
 			$videoTime = Get-Date -Date $timestamp -Format "yyyy-MM-dd_HH-mm-ss"
 
 			# Download address of video clip
-			$videoURL = 'https://rest-'+ $region +'.immedia-semi.com' + $address
+			$videoURL = 'https://rest-'+ $script:region +'.immedia-semi.com' + $address
 			
 			# Download video if it is new
 			$path = "$saveDirectory\Blink\$network\$camera"
 			$videoPath = "$path\$videoTime.mp4"
 			if (-not (Test-Path $videoPath)){
 				try {
-					Invoke-RestMethod -UseBasicParsing $videoURL -Method Get -Headers $headers -OutFile $videoPath 
-					$httpCode = $_.Exception.Response.StatusCode.value__        
+					# Use fresh headers for each video download
+					Invoke-RestMethod -UseBasicParsing $videoURL -Method Get -Headers (Get-AuthHeaders) -OutFile $videoPath 
+					$httpCode = $_.Exception.Response.StatusCode.value__		
 					if($httpCode -ne 404){
 						echo "Downloading video for $camera camera in $network."
+						$videoCount++
 					}   
 				} catch { 
 					# Left empty to prevent spam when video file no longer exists
@@ -226,6 +399,11 @@ while (1)
 		}
 		$pageNum += 1
 	}
+	
+	if ($videoCount -gt 0) {
+		echo "Downloaded $videoCount new videos in this cycle."
+	}
+	
 	echo "All new videos and thumbnails downloaded to $saveDirectory\Blink\"
 	echo "Sleeping for 30 minutes before next run..."
 	# Sleep for 30 minutes

--- a/BlinkVideoDownloader.ps1
+++ b/BlinkVideoDownloader.ps1
@@ -2,7 +2,7 @@
 #
 # Author: Nayrk
 # Date: 12/28/2018
-# Last Updated: 11/23/2025
+# Last Updated: 12/07/2025
 # Purpose: To download all Blink videos locally to the PC. Existing videos will be skipped.
 # Output: All Blink videos downloaded in the following directory format.
 #         Default Location Desktop - "C:\temp\Blink"
@@ -15,6 +15,7 @@
 # Fixed By: tyuhas on 02/03/2021
 # Fixed By: ttteee90 on 03/19/2021
 # Fixed By: tpgal on 11/23/2025 - OAuth2 migration fix
+# Fixed By: tpgal on 12/07/2025 - New OAuth2 with PKCE Authorization Code Flow
 #             Solution based on blinkpy's OAuth2 implementation (https://github.com/fronzbot/blinkpy)
 #             Adapted to PowerShell by Claude Sonnet 4.5 (Anthropic)
 #             Analysis and debugging with user collaboration
@@ -22,6 +23,7 @@
 #          03/22/2021 - Cleaned up the code and added more debug messages. Added try/catch on invalid pin.
 #          11/23/2025 - Migrated to OAuth2 authentication endpoint with automatic token refresh and 2FA support
 #          11/30/2025 - Updated to download thumbnails getting url from the homescreen endpoint
+#          12/07/2025 - Updated to support PKCE
 #######################################################################################################################
 
 # Change saveDirectory directory if you want the Blink Files to be saved somewhere else, default is user Desktop
@@ -33,18 +35,21 @@ $saveDirectory = "C:\temp\Blink"
 $email = "Your Email Here"
 $password = "Your Password Here"
 
-# Blink's API Server, this is the URL you are directed to when you are prompted for IFTTT Integration to "Grant Access"
-# You can verify this yourself to make sure you are sending the data where you expect it to be
+# Blink's API Server
 $blinkAPIServer = 'rest-prod.immedia-semi.com'
 
 # Use this server below if you are in Germany. Remove the # symbol below.
 # $blinkAPIServer = 'prde.immedia-semi.com'
 
-# OAuth Constants (New for 2025)
-$oauthServer = 'api.oauth.blink.com'
-$oauthClientId = 'android'
-$oauthGrantType = 'password'
+# OAuth v2 Constants
+$oauthBaseUrl = 'https://api.oauth.blink.com'
+$oauthClientId = 'ios'
 $oauthScope = 'client'
+$oauthRedirectUri = 'immedia-blink://applinks.blink.com/signin/callback'
+
+# User-Agents (simulating iOS Safari)
+$oauthUserAgent = 'Mozilla/5.0 (iPhone; CPU iPhone OS 18_7 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.1 Mobile/15E148 Safari/604.1'
+$oauthTokenUserAgent = 'Blink/2511191620 CFNetwork/3860.200.71 Darwin/25.1.0'
 
 #######################################################################################################################
 #
@@ -55,29 +60,8 @@ $oauthScope = 'client'
 if($email -eq "Your Email Here") { Write-Host 'Please enter your email by modifying the line: $email = "Your Email Here"'; pause; exit;}
 if($password -eq "Your Password Here") { Write-Host 'Please enter your password by modifying the line: $password = "Your Password Here"'; pause; exit;}
 
-# Function to URL-encode a string (compatible with all PowerShell versions)
-function ConvertTo-UrlEncoded {
-    param([string]$Value)
-    
-    # Character map for URL encoding
-    $urlEncoded = ""
-    foreach ($char in $Value.ToCharArray()) {
-        $ascii = [int][char]$char
-        
-        # Check if character needs encoding
-        if (($ascii -ge 48 -and $ascii -le 57) -or   # 0-9
-            ($ascii -ge 65 -and $ascii -le 90) -or   # A-Z
-            ($ascii -ge 97 -and $ascii -le 122) -or  # a-z
-            $char -eq '-' -or $char -eq '_' -or 
-            $char -eq '.' -or $char -eq '~') {
-            $urlEncoded += $char
-        } else {
-            # Encode the character as %XX
-            $urlEncoded += '%' + ([System.String]::Format("{0:X2}", $ascii))
-        }
-    }
-    return $urlEncoded
-}
+#Load System.Web for URL encoding
+Add-Type -AssemblyName System.Web
 
 # Global variables for token management
 $script:authToken = $null
@@ -85,67 +69,358 @@ $script:refreshToken = $null
 $script:tokenExpirationTime = $null
 $script:region = $null
 $script:accountID = $null
-$script:lastTokenCheck = 0
+$script:hardwareId = [guid]::NewGuid().ToString().ToUpper()
 
-# Function to perform OAuth login
-function Invoke-BlinkLogin {
+# Function to generate PKCE pair
+function New-PKCEPair {
+    # Generate code_verifier (43-128 characters, URL-safe base64)
+    $bytes = New-Object byte[] 32
+    [System.Security.Cryptography.RandomNumberGenerator]::Create().GetBytes($bytes)
+    $codeVerifier = [Convert]::ToBase64String($bytes).TrimEnd('=').Replace('+', '-').Replace('/', '_')
+    
+    # Generate code_challenge (SHA256 hash of verifier, URL-safe base64)
+    $sha256 = [System.Security.Cryptography.SHA256]::Create()
+    $challengeBytes = $sha256.ComputeHash([System.Text.Encoding]::UTF8.GetBytes($codeVerifier))
+    $codeChallenge = [Convert]::ToBase64String($challengeBytes).TrimEnd('=').Replace('+', '-').Replace('/', '_')
+    
+    return @{
+        Verifier = $codeVerifier
+        Challenge = $codeChallenge
+    }
+}
+
+# Function to extract CSRF token from HTML
+function Get-CSRFToken {
+    param([string]$Html)
+    
+    # Extract CSRF token from oauth-args script tag
+    if ($Html -match '<script[^>]*id="oauth-args"[^>]*type="application/json"[^>]*>(.*?)</script>') {
+        $jsonContent = $Matches[1]
+        try {
+            $oauthData = $jsonContent | ConvertFrom-Json
+            return $oauthData.'csrf-token'
+        } catch {
+            Write-Host "Failed to parse OAuth args JSON" -ForegroundColor Red
+        }
+    }
+    return $null
+}
+
+# Step 1: OAuth Authorization Request
+function Invoke-OAuthAuthorize {
+    param($CodeChallenge)
+    
+    $params = @{
+        'app_brand' = 'blink'
+        'app_version' = '50.1'
+        'client_id' = $oauthClientId
+        'code_challenge' = $CodeChallenge
+        'code_challenge_method' = 'S256'
+        'device_brand' = 'Apple'
+        'device_model' = 'iPhone16,1'
+        'device_os_version' = '26.1'
+        'hardware_id' = $script:hardwareId
+        'redirect_uri' = $oauthRedirectUri
+        'response_type' = 'code'
+        'scope' = $oauthScope
+    }
+    
+    $queryString = ($params.GetEnumerator() | ForEach-Object { "$($_.Key)=$([System.Web.HttpUtility]::UrlEncode($_.Value))" }) -join '&'
+    $url = "$oauthBaseUrl/oauth/v2/authorize?$queryString"
+    
+    $headers = @{
+        'User-Agent' = $oauthUserAgent
+        'Accept' = 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8'
+        'Accept-Language' = 'en-US,en;q=0.9'
+    }
+    
+    try {
+        $response = Invoke-WebRequest -Uri $url -Method Get -Headers $headers -SessionVariable 'oauthSession' -UseBasicParsing -ErrorAction Stop
+        $script:oauthSession = $oauthSession
+        return $response.StatusCode -eq 200
+    } catch {
+        Write-Host "OAuth Authorization failed: $($_.Exception.Message)" -ForegroundColor Red
+        return $false
+    }
+}
+
+# Step 2: Get Signin Page and Extract CSRF Token
+function Get-SigninPageCSRF {
+    $url = "$oauthBaseUrl/oauth/v2/signin"
+    
+    $headers = @{
+        'User-Agent' = $oauthUserAgent
+        'Accept' = 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8'
+        'Accept-Language' = 'en-US,en;q=0.9'
+    }
+    
+    try {
+        $response = Invoke-WebRequest -Uri $url -Method Get -Headers $headers -WebSession $script:oauthSession -UseBasicParsing -ErrorAction Stop
+        $csrfToken = Get-CSRFToken -Html $response.Content
+        return $csrfToken
+    } catch {
+        Write-Host "Failed to get signin page: $($_.Exception.Message)" -ForegroundColor Red
+        return $null
+    }
+}
+
+# Step 3: Submit Login Credentials
+function Submit-LoginCredentials {
     param(
-        [string]$TwoFactorCode = $null,
-        [switch]$IsRefresh = $false
+        [string]$CsrfToken
     )
     
-    # Headers for OAuth login
-    $loginHeaders = @{
-        "Content-Type" = "application/x-www-form-urlencoded"
-        "User-Agent" = "Blinkpy/0.22.0"
-        "hardware_id" = "Blinkpy"
+    $url = "$oauthBaseUrl/oauth/v2/signin"
+    
+    $headers = @{
+        'User-Agent' = $oauthUserAgent
+        'Accept' = '*/*'
+        'Content-Type' = 'application/x-www-form-urlencoded'
+        'Origin' = $oauthBaseUrl
+        'Referer' = "$oauthBaseUrl/oauth/v2/signin"
     }
     
-    # Add 2FA code to headers if provided
-    if ($TwoFactorCode) {
-        $loginHeaders["2fa-code"] = $TwoFactorCode
+    $body = @{
+        'username' = $email
+        'password' = $password
+        'csrf-token' = $CsrfToken
     }
-
-    # Credential data in URL-encoded format
-    if ($IsRefresh -and $script:refreshToken) {
-        # Use refresh token for renewal
-        $bodyParams = @{
-            "grant_type" = "refresh_token"
-            "refresh_token" = $script:refreshToken
-            "client_id" = $oauthClientId
-        }
-    } else {
-        # Use credentials for initial login
-        $bodyParams = @{
-            "username" = $email
-            "password" = $password
-            "grant_type" = $oauthGrantType
-            "client_id" = $oauthClientId
-            "scope" = $oauthScope
-        }
-    }
-
-    # Convert to URL-encoded string
-    $bodyString = ($bodyParams.GetEnumerator() | ForEach-Object { "$($_.Key)=$(ConvertTo-UrlEncoded $_.Value)" }) -join '&'
-
-    # OAuth Login URL
-    $loginUri = "https://$oauthServer/oauth/token"
-
-    # Authenticate credentials with Blink OAuth Server
+    
+    $bodyString = ($body.GetEnumerator() | ForEach-Object { "$($_.Key)=$([System.Web.HttpUtility]::UrlEncode($_.Value))" }) -join '&'
+    
     try {
-        $response = Invoke-RestMethod -UseBasicParsing $loginUri -Method Post -Headers $loginHeaders -Body $bodyString -ErrorAction Stop
-        return @{
-            Success = $true
-            Response = $response
+        $response = Invoke-WebRequest -Uri $url -Method Post -Headers $headers -Body $bodyString -WebSession $script:oauthSession -MaximumRedirection 0 -ErrorAction SilentlyContinue
+        
+        # Check status code
+        if ($response.StatusCode -eq 412) {
+            return "2FA_REQUIRED"
+        } elseif ($response.StatusCode -in @(301, 302, 303, 307, 308)) {
+            return "SUCCESS"
         }
+        
+        return $null
     } catch {
-        $statusCode = $_.Exception.Response.StatusCode.Value__
-        return @{
-            Success = $false
-            StatusCode = $statusCode
-            Error = $_.Exception.Message
+        # PowerShell treats 3xx as errors if MaximumRedirection=0
+        if ($_.Exception.Response.StatusCode.Value__ -in @(301, 302, 303, 307, 308)) {
+            return "SUCCESS"
+        } elseif ($_.Exception.Response.StatusCode.Value__ -eq 412) {
+            return "2FA_REQUIRED"
+        }
+        
+        Write-Host "Login submission failed: $($_.Exception.Message)" -ForegroundColor Red
+        return $null
+    }
+}
+
+# Step 3b: Verify 2FA Code
+function Submit-2FACode {
+    param(
+        [string]$CsrfToken,
+        [string]$TwoFactorCode
+    )
+    
+    $url = "$oauthBaseUrl/oauth/v2/2fa/verify"
+    
+    $headers = @{
+        'User-Agent' = $oauthUserAgent
+        'Accept' = '*/*'
+        'Content-Type' = 'application/x-www-form-urlencoded'
+        'Origin' = $oauthBaseUrl
+        'Referer' = "$oauthBaseUrl/oauth/v2/signin"
+    }
+    
+    $body = @{
+        '2fa_code' = $TwoFactorCode
+        'csrf-token' = $CsrfToken
+        'remember_me' = 'false'
+    }
+    
+    $bodyString = ($body.GetEnumerator() | ForEach-Object { "$($_.Key)=$([System.Web.HttpUtility]::UrlEncode($_.Value))" }) -join '&'
+    
+    try {
+        $response = Invoke-RestMethod -Uri $url -Method Post -Headers $headers -Body $bodyString -WebSession $script:oauthSession -ErrorAction Stop
+        return $response.status -eq "auth-completed"
+    } catch {
+        Write-Host "2FA verification failed: $($_.Exception.Message)" -ForegroundColor Red
+        return $false
+    }
+}
+
+# Step 4: Get Authorization Code
+function Get-AuthorizationCode {
+    $url = "$oauthBaseUrl/oauth/v2/authorize"
+    
+    $headers = @{
+        'User-Agent' = $oauthUserAgent
+        'Accept' = '*/*'
+        'Referer' = "$oauthBaseUrl/oauth/v2/signin"
+    }
+    
+    try {
+        $response = Invoke-WebRequest -Uri $url -Method Get -Headers $headers -WebSession $script:oauthSession -MaximumRedirection 0 -ErrorAction SilentlyContinue
+        
+        # Should redirect to blink://... with code parameter
+        if ($response.Headers.Location) {
+            $location = $response.Headers.Location
+            if ($location -match '[?&]code=([^&]+)') {
+                return $Matches[1]
+            }
+        }
+        
+        return $null
+    } catch {
+        # Check redirect location in exception
+        if ($_.Exception.Response.Headers.Location) {
+            $location = $_.Exception.Response.Headers.Location.ToString()
+            if ($location -match '[?&]code=([^&]+)') {
+                return $Matches[1]
+            }
+        }
+        
+        Write-Host "Failed to get authorization code: $($_.Exception.Message)" -ForegroundColor Red
+        return $null
+    }
+}
+
+# Step 5: Exchange Code for Token
+function Get-AccessToken {
+    param(
+        [string]$Code,
+        [string]$CodeVerifier
+    )
+    
+    $url = "$oauthBaseUrl/oauth/token"
+    
+    $headers = @{
+        'User-Agent' = $oauthTokenUserAgent
+        'Content-Type' = 'application/x-www-form-urlencoded'
+        'Accept' = '*/*'
+    }
+    
+    $body = @{
+        'app_brand' = 'blink'
+        'client_id' = $oauthClientId
+        'code' = $Code
+        'code_verifier' = $CodeVerifier
+        'grant_type' = 'authorization_code'
+        'hardware_id' = $script:hardwareId
+        'redirect_uri' = $oauthRedirectUri
+        'scope' = $oauthScope
+    }
+    
+    $bodyString = ($body.GetEnumerator() | ForEach-Object { "$($_.Key)=$([System.Web.HttpUtility]::UrlEncode($_.Value))" }) -join '&'
+    
+    try {
+        $response = Invoke-RestMethod -Uri $url -Method Post -Headers $headers -Body $bodyString -ErrorAction Stop
+        return $response
+    } catch {
+        Write-Host "Failed to exchange code for token: $($_.Exception.Message)" -ForegroundColor Red
+        return $null
+    }
+}
+
+# Complete OAuth Flow
+function Invoke-OAuthLogin {
+    echo "Starting OAuth2 login flow with PKCE..."
+    
+    # Step 1: Generate PKCE pair
+    echo "Generating PKCE pair..."
+    $pkce = New-PKCEPair
+    
+    # Step 2: Authorization request
+    echo "Sending authorization request..."
+    if (-not (Invoke-OAuthAuthorize -CodeChallenge $pkce.Challenge)) {
+        Write-Host "Authorization request failed" -ForegroundColor Red
+        return $null
+    }
+    
+    # Step 3: Get CSRF token
+    echo "Getting CSRF token..."
+    $csrfToken = Get-SigninPageCSRF
+    if (-not $csrfToken) {
+        Write-Host "Failed to get CSRF token" -ForegroundColor Red
+        return $null
+    }
+    
+    # Step 4: Submit login
+    echo "Submitting credentials..."
+    $loginResult = Submit-LoginCredentials -CsrfToken $csrfToken
+    
+    # Step 4b: Handle 2FA if needed
+    if ($loginResult -eq "2FA_REQUIRED") {
+        Write-Host "`nTwo-factor authentication required." -ForegroundColor Yellow
+        Write-Host "Please check your email or SMS for the 2FA code." -ForegroundColor Yellow
+        $twoFactorCode = Read-Host -Prompt "Enter your 2FA code"
+        
+        echo "Verifying 2FA code..."
+        if (-not (Submit-2FACode -CsrfToken $csrfToken -TwoFactorCode $twoFactorCode)) {
+            Write-Host "2FA verification failed" -ForegroundColor Red
+            return $null
+        }
+    } elseif ($loginResult -ne "SUCCESS") {
+        Write-Host "Login failed" -ForegroundColor Red
+        return $null
+    }
+    
+    # Step 5: Get authorization code
+    echo "Getting authorization code..."
+    $code = Get-AuthorizationCode
+    if (-not $code) {
+        Write-Host "Failed to get authorization code" -ForegroundColor Red
+        return $null
+    }
+    
+    # Step 6: Exchange code for token
+    echo "Exchanging code for access token..."
+    $tokenData = Get-AccessToken -Code $code -CodeVerifier $pkce.Verifier
+    if (-not $tokenData) {
+        Write-Host "Failed to get access token" -ForegroundColor Red
+        return $null
+    }
+    
+    return $tokenData
+}
+
+# Function to refresh token
+function Update-AuthToken {
+    if ($script:refreshToken) {
+        echo "Refreshing access token..."
+        
+        $url = "$oauthBaseUrl/oauth/token"
+        
+        $headers = @{
+            'User-Agent' = $oauthTokenUserAgent
+            'Content-Type' = 'application/x-www-form-urlencoded'
+            'Accept' = '*/*'
+        }
+        
+        $body = @{
+            'grant_type' = 'refresh_token'
+            'refresh_token' = $script:refreshToken
+            'client_id' = $oauthClientId
+            'scope' = $oauthScope
+            'hardware_id' = $script:hardwareId
+        }
+        
+        $bodyString = ($body.GetEnumerator() | ForEach-Object { "$($_.Key)=$([System.Web.HttpUtility]::UrlEncode($_.Value))" }) -join '&'
+        
+        try {
+            $tokenData = Invoke-RestMethod -Uri $url -Method Post -Headers $headers -Body $bodyString -ErrorAction Stop
+            
+            $script:authToken = $tokenData.access_token
+            $script:refreshToken = $tokenData.refresh_token
+            
+            $currentTime = [Math]::Floor([decimal](Get-Date(Get-Date).ToUniversalTime()-uformat "%s"))
+            $script:tokenExpirationTime = $currentTime + $tokenData.expires_in
+            
+            echo "Token refreshed successfully"
+            return $true
+        } catch {
+            Write-Host "Token refresh failed: $($_.Exception.Message)" -ForegroundColor Yellow
+            return $false
         }
     }
+    return $false
 }
 
 # Function to check if token needs refresh
@@ -161,62 +436,12 @@ function Test-TokenNeedsRefresh {
     return $timeUntilExpiration -lt 300
 }
 
-# Function to refresh authentication token
-function Update-AuthToken {
-    param(
-        [switch]$Force = $false
-    )
-    
-    if ($Force -or (Test-TokenNeedsRefresh)) {
-        echo "Token expiring soon, refreshing authentication..."
-        
-        # Try to refresh using refresh_token first
-        $refreshResult = Invoke-BlinkLogin -IsRefresh
-        
-        # If refresh fails, do a full re-login
-        if (-not $refreshResult.Success) {
-            echo "Refresh token failed, performing full re-authentication..."
-            $refreshResult = Invoke-BlinkLogin
-            
-            # Check if 2FA is required
-            if (-not $refreshResult.Success -and $refreshResult.StatusCode -eq 412) {
-                Write-Host "Two-factor authentication required. Please check your email or SMS for the 2FA code."
-                $twoFactorCode = Read-Host -Prompt "Enter your 2FA code"
-                
-                if (-not $twoFactorCode -or $twoFactorCode.Trim() -eq "") {
-                    Write-Host "No 2FA code provided. Cannot refresh token."
-                    return $false
-                }
-                
-                $refreshResult = Invoke-BlinkLogin -TwoFactorCode $twoFactorCode
-            }
-        }
-        
-        if ($refreshResult.Success) {
-            $response = $refreshResult.Response
-            $script:authToken = $response.access_token
-            $script:refreshToken = $response.refresh_token
-            
-            # Calculate expiration time (current time + expires_in)
-            $currentTime = [Math]::Floor([decimal](Get-Date(Get-Date).ToUniversalTime()-uformat "%s"))
-            $script:tokenExpirationTime = $currentTime + $response.expires_in
-            $script:lastTokenCheck = $currentTime
-            
-            echo "Token refreshed successfully. Valid for $($response.expires_in) seconds."
-            return $true
-        } else {
-            Write-Host "Failed to refresh token. Script may stop working."
-            return $false
-        }
-    }
-    return $true
-}
-
 # Function to get current auth headers (always fresh)
 function Get-AuthHeaders {
-    # Check token every time headers are requested
-    if (-not (Update-AuthToken)) {
-        Write-Host "Warning: Unable to refresh token, using potentially expired token."
+    if (Test-TokenNeedsRefresh) {
+        if (-not (Update-AuthToken)) {
+            Write-Host "Warning: Unable to refresh token" -ForegroundColor Yellow
+        }
     }
     
     return @{
@@ -225,91 +450,49 @@ function Get-AuthHeaders {
     }
 }
 
-# Initial login attempt
-echo "Performing initial authentication..."
-$loginResult = Invoke-BlinkLogin
+# Perform OAuth login
+$tokenData = Invoke-OAuthLogin
 
-# Check if 2FA is required (HTTP 412)
-if (-not $loginResult.Success -and $loginResult.StatusCode -eq 412) {
-    Write-Host "Two-factor authentication required. Please check your email or SMS for the 2FA code."
-    $twoFactorCode = Read-Host -Prompt "Enter your 2FA code"
-    
-    if (-not $twoFactorCode -or $twoFactorCode.Trim() -eq "") {
-        Write-Host "No 2FA code provided. Exiting."
-        pause
-        exit
-    }
-    
-    # Retry login with 2FA code
-    $loginResult = Invoke-BlinkLogin -TwoFactorCode $twoFactorCode
-}
-
-# Check final login result
-if (-not $loginResult.Success) {
-    Write-Host "Login failed. Please verify your credentials and try again."
+if (-not $tokenData) {
+    Write-Host "Login failed. Exiting." -ForegroundColor Red
     pause
     exit
 }
 
-$response = $loginResult.Response
+# Extract tokens
+$script:authToken = $tokenData.access_token
+$script:refreshToken = $tokenData.refresh_token
+$expiresIn = $tokenData.expires_in
 
-if(-not $response){
-    echo "No response received from server."
-    pause
-    exit
-}
-
-# Extract OAuth token and set expiration time
-$script:authToken = $response.access_token
-$script:refreshToken = $response.refresh_token
-$expiresIn = $response.expires_in
-
-# Calculate expiration time
 $currentTime = [Math]::Floor([decimal](Get-Date(Get-Date).ToUniversalTime()-uformat "%s"))
 $script:tokenExpirationTime = $currentTime + $expiresIn
-$script:lastTokenCheck = $currentTime
 
-if(-not $script:authToken) {
-    Write-Host "Failed to obtain access token. Please try again."
-    pause
-    exit
-}
-
-$expirationDate = (Get-Date).AddSeconds($expiresIn)
-echo "Access token obtained (valid for $expiresIn seconds, expires at $($expirationDate.ToString('HH:mm:ss')))"
+echo "`nLogin successful!"
+echo "Access token obtained (expires in $expiresIn seconds)"
 
 # Get tier information
 $tierUri = "https://$blinkAPIServer/api/v1/users/tier_info"
 $tierHeaders = @{
     "Content-Type" = "application/json"
     "Authorization" = "Bearer $script:authToken"
-    "User-Agent" = "Blinkpy/0.22.0"
 }
 
 try {
     $tierResponse = Invoke-RestMethod -UseBasicParsing $tierUri -Method Get -Headers $tierHeaders -ErrorAction Stop
+    $script:region = $tierResponse.tier
+    $script:accountID = $tierResponse.account_id
+    echo "Region: $script:region, Account ID: $script:accountID"
 } catch {
-    Write-Host "Failed to get account information. Please try again."
+    Write-Host "Failed to get tier info" -ForegroundColor Red
     pause
     exit
 }
 
-# Extract tier data
-$script:region = $tierResponse.tier
-$script:accountID = $tierResponse.account_id
-
-if(-not $script:region -or -not $script:accountID) {
-    Write-Host "Failed to obtain account details. Please try again."
-    pause
-    exit
-}
-
-echo "Authenticated with Blink successfully (Region: $script:region, Account: $script:accountID)"
-
+# Main download loop
 while (1)
 {
-	echo "`nStarting download cycle..."
-	
+    echo "`nStarting download cycle..."
+    
     # Get homescreen info - single endpoint with all camera and network data
     $homescreenUri = "https://rest-$script:region.immedia-semi.com/api/v3/accounts/$script:accountID/homescreen"
     $homescreen = Invoke-RestMethod -UseBasicParsing $homescreenUri -Method Get -Headers (Get-AuthHeaders)
@@ -366,48 +549,48 @@ while (1)
             }
         }
     }
+    
+    # Download videos
+    $pageNum = 1
+    $videoCount = 0
 
-	$pageNum = 1
-	$videoCount = 0
+    # Continue to download videos from each page until all are downloaded
+    while ( 1 )
+    {
+        # Get media list with fresh headers
+        $uri = 'https://rest-'+ $script:region +'.immedia-semi.com/api/v1/accounts/'+ $script:accountID +'/media/changed?since=2015-04-19T23:11:20+0000&page=' + $pageNum
+        $response = Invoke-RestMethod -UseBasicParsing $uri -Method Get -Headers (Get-AuthHeaders)
+        
+        # No more videos to download, exit from loop
+        if(-not $response.media){
+            break
+        }
 
-	# Continue to download videos from each page until all are downloaded
-	while ( 1 )
-	{
-		# Get media list with fresh headers
-		$uri = 'https://rest-'+ $script:region +'.immedia-semi.com/api/v1/accounts/'+ $script:accountID +'/media/changed?since=2015-04-19T23:11:20+0000&page=' + $pageNum
-		$response = Invoke-RestMethod -UseBasicParsing $uri -Method Get -Headers (Get-AuthHeaders)
-		
-		# No more videos to download, exit from loop
-		if(-not $response.media){
-			break
-		}
+        # Go through each video information and get the download link and relevant information
+        foreach($video in $response.media){
+            # Video clip information
+            $address = $video.media
+            $timestamp = $video.created_at
+            $network = $video.network_name
+            $camera = $video.device_name
+            $deleted = $video.deleted
+            if($deleted -eq "True"){
+                continue
+            }
+           
+            # Get video timestamp in local time
+            $videoTime = Get-Date -Date $timestamp -Format "yyyy-MM-dd_HH-mm-ss"
 
-		# Go through each video information and get the download link and relevant information
-		foreach($video in $response.media){
-			# Video clip information
-			$address = $video.media
-			$timestamp = $video.created_at
-			$network = $video.network_name
-			$camera = $video.device_name
-			$camera_id = $video.camera_id
-			$deleted = $video.deleted
-			if($deleted -eq "True"){
-				continue
-			}
-		   
-			# Get video timestamp in local time
-			$videoTime = Get-Date -Date $timestamp -Format "yyyy-MM-dd_HH-mm-ss"
-
-			# Download address of video clip
-			$videoURL = 'https://rest-'+ $script:region +'.immedia-semi.com' + $address
-			
-			# Download video if it is new
-			$path = "$saveDirectory\Blink\$network\$camera"
-			$videoPath = "$path\$videoTime.mp4"
-			if (-not (Test-Path $videoPath)){
-				try {
-					# Use fresh headers for each video download
-					Invoke-RestMethod -UseBasicParsing $videoURL -Method Get -Headers (Get-AuthHeaders) -OutFile $videoPath 
+            # Download address of video clip
+            $videoURL = 'https://rest-'+ $script:region +'.immedia-semi.com' + $address
+            
+            # Download video if it is new
+            $path = "$saveDirectory\Blink\$network\$camera"
+            $videoPath = "$path\$videoTime.mp4"
+            if (-not (Test-Path $videoPath)){
+                try {
+                    # Use fresh headers for each video download
+                    Invoke-RestMethod -UseBasicParsing $videoURL -Method Get -Headers (Get-AuthHeaders) -OutFile $videoPath 
 					$httpCode = $_.Exception.Response.StatusCode.value__		
 					if($httpCode -ne 404){
 						echo "Downloading video for $camera camera in $network."
@@ -416,18 +599,18 @@ while (1)
 				} catch { 
 					# Left empty to prevent spam when video file no longer exists
 					echo $httpCode
-				}
-			}
-		}
-		$pageNum += 1
-	}
-	
-	if ($videoCount -gt 0) {
-		echo "Downloaded $videoCount new videos in this cycle."
-	}
-	
+                }
+            }
+        }
+        $pageNum += 1
+    }
+    
+    if ($videoCount -gt 0) {
+        echo "Downloaded $videoCount new videos in this cycle."
+    }
+    
 	echo "All new videos and thumbnails downloaded to $saveDirectory\Blink\"
 	echo "Sleeping for 30 minutes before next run..."
 	# Sleep for 30 minutes
-	Start-Sleep -S 1800
+    Start-Sleep -S 1800
 }

--- a/BlinkVideoDownloader.ps1
+++ b/BlinkVideoDownloader.ps1
@@ -24,6 +24,7 @@
 #          11/23/2025 - Migrated to OAuth2 authentication endpoint with automatic token refresh and 2FA support
 #          11/30/2025 - Updated to download thumbnails getting url from the homescreen endpoint
 #          12/07/2025 - Updated to support PKCE
+#          06/27/2026 - Support to return code 202 for 2FA-signin
 #######################################################################################################################
 
 # Change saveDirectory directory if you want the Blink Files to be saved somewhere else, default is user Desktop
@@ -192,7 +193,7 @@ function Submit-LoginCredentials {
         $response = Invoke-WebRequest -Uri $url -Method Post -Headers $headers -Body $bodyString -WebSession $script:oauthSession -MaximumRedirection 0 -ErrorAction SilentlyContinue
         
         # Check status code
-        if ($response.StatusCode -eq 412) {
+        if ($response.StatusCode -in @(202, 412)) {
             return "2FA_REQUIRED"
         } elseif ($response.StatusCode -in @(301, 302, 303, 307, 308)) {
             return "SUCCESS"
@@ -203,7 +204,7 @@ function Submit-LoginCredentials {
         # PowerShell treats 3xx as errors if MaximumRedirection=0
         if ($_.Exception.Response.StatusCode.Value__ -in @(301, 302, 303, 307, 308)) {
             return "SUCCESS"
-        } elseif ($_.Exception.Response.StatusCode.Value__ -eq 412) {
+        } elseif ($_.Exception.Response.StatusCode.Value__ -in @(202, 412)) {
             return "2FA_REQUIRED"
         }
         


### PR DESCRIPTION
## Problem
The original script stopped working in mid-October 2024 due to Blink API changes.
The error "An app update is required" appeared on all login attempts.

## Solution
This PR updates the script to use the new OAuth2 authentication endpoint.

### Key Changes:
   - Migrated from API v4/v5 to OAuth2 endpoint (api.oauth.blink.com)
   - Added automatic token refresh mechanism
   - Added 2FA support via header

### Testing
   - Tested on Windows 11 with PowerShell 5.1+
   - Successfully authenticates with 2FA
   - Downloads videos and thumbnails correctly
   - Token refresh working after multiple hours of execution

Fixes issues reported in October-November 2025 by multiple users.